### PR TITLE
Fixes semicolon

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ var options = {
    ]
 };
 
-hellosign.signatureRequest.sendWithTemplate(options);
+hellosign.signatureRequest.sendWithTemplate(options)
   .then(function(res){
     console.log(res.signature_request);
   });


### PR DESCRIPTION
This is just a small fix for the Readme.  I used this code and noticed the mistake.
