### PR TITLE
Not overwriting all error messages

### DIFF
--- a/lib/HelloSignResource.js
+++ b/lib/HelloSignResource.js
@@ -201,12 +201,15 @@ HelloSignResource.prototype = {
         var self = this;
         return function(error) {
             if (req._isAborted) return; // already handled
-            callback.call(
-                self,
-                new Error.HelloSignConnectionError({
+            if (!error || !error.message) {
+                error = {
                     message: 'An error occurred with our connection to HelloSign',
                     detail: error
-                }),
+                };
+            }
+            callback.call(
+                self,
+                new Error.HelloSignConnectionError(error),
                 null
             );
         }


### PR DESCRIPTION
We talked about this about a week ago. There was a problem with downloading a particular document only with the Node SDK, and I could not debug it because all the error said was 'An error occurred with our connection to HelloSign'. Hopefully this will make debugging easier in the future.
