### PR TITLE
feature(file buffer): Support in-memory file buffers

### DIFF
--- a/lib/HelloSignResource.js
+++ b/lib/HelloSignResource.js
@@ -331,11 +331,19 @@ HelloSignResource.prototype = {
             // submit as form
             var form = new FormData();
             for(var i=0; i<data.files.length;i++) {
-                form.append("file[" + i + "]", fs.createReadStream(data.files[i]));
+                if( typeof data.files[i] === 'string' ) {
+                    form.append("file[" + i + "]", fs.createReadStream(data.files[i]));
+                }
+                else if( data.files[i] instanceof Buffer ) {
+                    form.append("file[" + i + "]", data.files[i], {filename: 'signature.pdf'});
+                }
+                else if( data.files[i] instanceof Object &&
+                        data.files[i].hasOwnProperty('file') && data.files[i].file instanceof Buffer ) {
+                    form.append("file[" + i + "]", data.files[i].file, {filename: data.files[i].name||'signature.pdf'});
+                }
             }
-            delete data.files;
             for(var paramName in data){
-                if(data.hasOwnProperty(paramName)){
+                if(paramName != 'files' && data.hasOwnProperty(paramName)){
                     form.append(paramName, data[paramName]);
                 }
             }


### PR DESCRIPTION
Enhance the HelloSign SDK to support file buffers instead of requiring
the use of temp-files. The support was added to include allowing the
caller to pass in the file name that is used by form.append( ) when
telling it that the Buffer should be treated as a file by giving it a
name.

Majority of any enterprise applications generate temporary files 
on a per request basis customized in some fashion. Having to
unnecessarily persist to disk just to attach the file for a signature
request is avoided by adding buffer support.