### PR TITLE
[DEV-4086] Upgrade Travis CI test environment(s)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
 node_js:
+  - "8"
+  - "9"
+  - "10"
   - "node"
-  - "iojs"
+  - "lts/*"


### PR DESCRIPTION
Previously, we were only running tests against the latest stable Node version as well as iojs (which became Node v4). Node 4 has been outdated for some time, [and as of 4/30/18 has reached the end of its life](https://github.com/nodejs/Release).

We will now run tests against Node versions 9 and 10, as well as all active LTS versions (non-maintenance) and the most recent stable version of Node.

```yml
node_js:
  - "8"
  - "9"
  - "10"
  - "node"
  - "lts/*"
```

Unblocks #35 