### PR TITLE
[DEV-4087] Update Node engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "bugs:": "apisupport@hellosign.com",
   "engines": {
-    "node": ">= v0.8.0"
+    "node": ">=8.0.0"
   },
   "main": "lib/hellosign.js",
   "dependencies": {


### PR DESCRIPTION
Previously the Node engine listed as supported in the package.json was Node >=0.8.0. This was not in fact true.

The Node engine has been updated so that it is consistent with our Travis test environment(s).