### PR TITLE
Updating README.md file to include the npm initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ A NodeJS / JavaScript wrapper for the [HelloSign API](http://www.hellosign.com/a
 
 Install from npm:
 ````sh
+# Optionally, to scaffolding your package.json first
+npm init
+
 npm install hellosign-sdk
 # Optionally, to install testing / development dependencies
 cd node_modules/hellosign-sdk

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ A NodeJS / JavaScript wrapper for the [HelloSign API](http://www.hellosign.com/a
 
 ## Installation
 
+First time using npm? Read more about installing npm packages here.
+
 Install from npm:
 ````sh
 # Optionally, to scaffold your package.json first

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A NodeJS / JavaScript wrapper for the [HelloSign API](http://www.hellosign.com/a
 
 Install from npm:
 ````sh
-# Optionally, to scaffolding your package.json first
+# Optionally, to scaffold your package.json first
 npm init
 
 npm install hellosign-sdk

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A NodeJS / JavaScript wrapper for the [HelloSign API](http://www.hellosign.com/a
 
 ## Installation
 
-First time using npm? Read more about installing npm packages here.
+First time using npm? Read more about installing npm packages [here] (https://docs.npmjs.com/downloading-and-installing-packages-locally).
 
 Install from npm:
 ````sh


### PR DESCRIPTION
Upon Stork's request, she wanted us to call out this first step `npm init` to initialize npm prior to install HS node SDK. So, users can avoid running into an issue when trying to cd node_modules/hellosign-sdk. So, we added that one note only:
Optionally, to scaffolding your package.json first
npm init
