### PR TITLE
Handle empty responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,13 +647,11 @@ var results = hellosign.template.createEmbeddedDraft(options)
 
 #### Delete Template
 ````javascript
-
 hellosign.template.delete(templateId)
-.catch((err) => {
-  console.error(err);
-})
-// No response to handle. No local callback will fire.
-// Catch and handle errors instead.
+    .then(function(res){
+        console.log(response.statusCode);
+        console.log(response.statusMessage);
+    })
 ````
 ### Unclaimed Draft
 

--- a/lib/HelloSignResource.js
+++ b/lib/HelloSignResource.js
@@ -194,6 +194,8 @@ HelloSignResource.prototype = {
                 response.statusCode = statusCode;
                 response.statusMessage = statusMessage;
                 callback.call(self, null, response);
+            } else {
+                callback.call(self, null, res);
             }
         };
     },

--- a/lib/HelloSignResource.js
+++ b/lib/HelloSignResource.js
@@ -188,7 +188,7 @@ HelloSignResource.prototype = {
             } else if ('content-transfer-encoding' in resHeaders && resHeaders['content-transfer-encoding'] == "binary"){
                 callback.call(self, null, res);
             // Simplified response for code-only statuses
-            } else if ('content-length' in resHeaders && resHeaders['content-length'] == "1") {
+            } else if ('content-length' in resHeaders && resHeaders['content-length'] <= "1") {
                 response = {};
                 response.resHeaders = resHeaders;
                 response.statusCode = statusCode;


### PR DESCRIPTION
Currently it's not possible to `await` (or `.then`) a cancel or delete request,
eg. the following will hang indefinitely if the signature request is cancelled
successfully:
```js
await hellosign.signatureRequest.cancel(sigId)
```

This PR teaches the response handler to deal with this case and resolve/
callback, and to handle any other unexpected cases without hanging.

Successful 'cancel' requests will respond with a success status and no
content. `_responseHandler` didn't have a path for that, as it wasn't
checking for the case where the content-length header has a value of 0.

I'm not sure which cases will reach this path and have a content-length
of 1, so I've left that behaviour as it is so we don't break anything!

Resolves #77
Resolves #50
Resolves #21