### PR TITLE
drop dependency on whenjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ hellosign.signatureRequest.send({/*options*/}, function(err, response){
 });
 ```
 
-Promise style access is through the [when](https://github.com/cujojs/when) library:
+Each method also returns a promise:
 
 ```javascript
 hellosign.signatureRequest.send({/*options*/})
@@ -93,9 +93,6 @@ hellosign.signatureRequest.send({/*options*/})
     .catch(function(err){
         //do something with error
     })
-    .finally(function(){
-        //optionally do yet another thing
-    });
 ```
 
 Returned promises are then-able, or can be returned for later resolution.

--- a/lib/HelloSignResource.js
+++ b/lib/HelloSignResource.js
@@ -27,7 +27,6 @@
 var http = require('http');
 var https = require('https');
 var path = require('path');
-var when = require('when');
 var FormData = require('form-data');
 var utils = require('./utils');
 var Error = require('./Error');
@@ -93,7 +92,11 @@ HelloSignResource.prototype = {
     },
 
     createDeferred: function(callback) {
-        var deferred = when.defer();
+        var deferred = {}
+        deferred.promise = new Promise((resolve, reject) => {
+            deferred.resolve = resolve;
+            deferred.reject = reject
+        })
 
         if (callback) {
             // Callback, if provided, is a simply translated to Promise'esque:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2457,11 +2457,6 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
-    "when": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/when/-/when-3.1.0.tgz",
-      "integrity": "sha1-okeWWcoV9yVUHs9S664JG3ge4TQ="
-    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
   "dependencies": {
     "expect": "^24.9.0",
     "express": "^4.17.1",
-    "form-data": "^2.3.2",
-    "when": "~3.1.0"
+    "form-data": "^2.3.2"
   },
   "scripts": {
     "test": "mocha test/unit",


### PR DESCRIPTION
So your dependency `when.js` has its last commit about 4 years ago - https://github.com/cujojs/when/commits/master

I am pushing all my backend code esbuild (it is deployed on lambda) - this dependency's archaic way of exporting modules was cause my build to fail.

I have my own fork now but I though I would make a pull just in case you wanted to merge this.
All the tests are passing but I am not sure if there is more testing that might need to be done ...
 