### PR TITLE
Added ability to accept Buffers as files

### DIFF
--- a/lib/HelloSignResource.js
+++ b/lib/HelloSignResource.js
@@ -334,7 +334,11 @@ HelloSignResource.prototype = {
             // submit as form
             var form = new FormData();
             for(var i=0; i<data.files.length;i++) {
-                form.append("file[" + i + "]", fs.createReadStream(data.files[i]));
+                if (typeof data.files[i] === 'string') {
+                    form.append("file[" + i + "]", fs.createReadStream(data.files[i]));
+                } else if (Buffer.isBuffer(data.files[i])) {
+                    form.append("file[" + i + "]", data.files[i]);
+                }
             }
             delete data.files;
             for(var paramName in data){

--- a/lib/HelloSignResource.js
+++ b/lib/HelloSignResource.js
@@ -334,10 +334,10 @@ HelloSignResource.prototype = {
             // submit as form
             var form = new FormData();
             for(var i=0; i<data.files.length;i++) {
-                if (typeof data.files[i] === 'string') {
-                    form.append("file[" + i + "]", fs.createReadStream(data.files[i]));
-                } else if (Buffer.isBuffer(data.files[i])) {
+                if (Buffer.isBuffer(data.files[i])) {
                     form.append("file[" + i + "]", data.files[i]);
+                } else {
+                    form.append("file[" + i + "]", fs.createReadStream(data.files[i]));
                 }
             }
             delete data.files;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hellosign-sdk",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hellosign-sdk",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "HelloSign NodeJS SDK",
   "homepage": "https://github.com/HelloFax/hellosign-nodejs-sdk",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hellosign-sdk",
+  "name": "@flexbase-eng/hellosign-sdk",
   "version": "1.7.0",
   "description": "HelloSign NodeJS SDK",
   "homepage": "https://github.com/HelloFax/hellosign-nodejs-sdk",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@flexbase-eng/hellosign-sdk",
+  "name": "hellosign-sdk",
   "version": "1.7.0",
   "description": "HelloSign NodeJS SDK",
   "homepage": "https://github.com/HelloFax/hellosign-nodejs-sdk",


### PR DESCRIPTION
We were really looking to use the Buffer capability of FormData, and the
only real issues we ran into were the ability to detect them, which
we've added, and the fact that the Buffers will have to have additional
properties assigned to them: .name and .contentType. If the user adds
these to the Buffer, once created with the contents of a file, then they
can simply put it in the files: [] argument to the function and it will
work just fine.