### PR TITLE
Remove 'when' dependency from hellosign-nodejs-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ hellosign.signatureRequest.send({/*options*/}, function(err, response){
 });
 ```
 
-Promise style access is through the [when](https://github.com/cujojs/when) library:
+Promise style access is through Javascript!
 
 ```javascript
 hellosign.signatureRequest.send({/*options*/})
@@ -243,7 +243,7 @@ var options = {
           signer_index: 1,
           required: 1,
         },
-      ],        
+      ],
     cc_email_addresses : ['lawyer@example.com', 'lawyer2@example.com'],
     files : ['my/docs/nda.pdf'],
     metadata : {

--- a/lib/HelloSignResource.js
+++ b/lib/HelloSignResource.js
@@ -27,7 +27,6 @@
 var http = require('http');
 var https = require('https');
 var path = require('path');
-var when = require('when');
 var FormData = require('form-data');
 var utils = require('./utils');
 var Error = require('./Error');
@@ -93,23 +92,35 @@ HelloSignResource.prototype = {
     },
 
     createDeferred: function(callback) {
-        var deferred = when.defer();
+        return (() => {
+            let resolve;
+            let reject;
 
-        if (callback) {
-            // Callback, if provided, is a simply translated to Promise'esque:
-            // (Ensure callback is called outside of promise stack)
-            deferred.promise.then(function(res) {
-                setTimeout(function(){
-                    callback(null, res)
-                }, 0);
-            }, function(err) {
-                setTimeout(function(){
-                    callback(err, null);
-                }, 0);
-            });
-        }
+            let p = new Promise((res, rej) => {
+                resolve = res;
+                reject = rej;
+            })
 
-        return deferred;
+            if (callback) {
+                // Callback, if provided, is a simply translated to Promise'esque:
+                // (Ensure callback is called outside of promise stack)
+                p.then(function(res) {
+                    setTimeout(function(){
+                        callback(null, res)
+                    }, 0);
+                }).catch(function(err) {
+                    setTimeout(function(){
+                        callback(err, null);
+                    }, 0);
+                });
+            }
+
+            return {
+                promise: p,
+                reject,
+                resolve
+            }
+        })()
     },
 
     _timeoutHandler: function(timeout, req, callback) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2457,11 +2457,6 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
-    "when": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/when/-/when-3.1.0.tgz",
-      "integrity": "sha1-okeWWcoV9yVUHs9S664JG3ge4TQ="
-    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
   "dependencies": {
     "expect": "^24.9.0",
     "express": "^4.17.1",
-    "form-data": "^2.3.2",
-    "when": "~3.1.0"
+    "form-data": "^2.3.2"
   },
   "scripts": {
     "test": "mocha test/unit",


### PR DESCRIPTION
Hey Yall!

Im a developer @ [Osmind](https://osmind.org). We were recently using the hellosign-sdk in a project w/ [esbuild](https://github.com/evanw/esbuild) and one of the dependencies blew up on us.

Specficially we were seeing errors with `when`:
```
"error":"Cannot find module './lib/decorators/timed'\nRequire stack:\n- /var/task/getHellosignTemplate.js\n- /var/task/s_getHellosignTemplate.js\n- /var/runtime/UserFunction.js\n- /var/runtime/index.js"}
```

I dug into the source code and noticed that `when` uses some shims to allow for browser compatibility which is causing our build to fail.

I've decided to add a PR to remove `when` as a dependency to this lib and instead use a method for deferred promises with the native Promise api. This should be supported Node 4+.

I've ran tests against my own code and the tests from the library and they seem to pass. Let me know if there is any other work that needs to be done to get this upstream