### PR TITLE
feat: Support directly passing file to API

### DIFF
--- a/lib/HelloSignResource.js
+++ b/lib/HelloSignResource.js
@@ -354,6 +354,19 @@ HelloSignResource.prototype = {
                 }
             }
             return {requestData: "", formData: form}
+        } else if ('filesData' in data && Array.isArray(data.filesData)){
+            // submit as multipart
+            var form = new FormData();
+            for(var i=0; i<data.filesData.length;i++) {
+                form.append("file[" + i + "]", data.filesData[i]);
+            }
+            delete data.filesData;
+            for(var paramName in data){
+                if(data.hasOwnProperty(paramName)){
+                    form.append(paramName, data[paramName]);
+                }
+            }
+            return {requestData: "", formData: form}
         } else {
             var requestData = utils.stringifyRequestData(data || {});
             return {requestData: requestData, formData: null}

--- a/lib/HelloSignResource.js
+++ b/lib/HelloSignResource.js
@@ -330,7 +330,7 @@ HelloSignResource.prototype = {
 
         for(var prop in data){
             if (data.hasOwnProperty(prop)){
-                if (typeof data[prop] === "object" && prop != "files"){
+                if (typeof data[prop] === "object" && prop !== "files" && prop !== "filesData"){
                     for(var paramName in data[prop]){
                         if(data[prop].hasOwnProperty(paramName)){
                             data[prop + "[" + paramName + "]"] = data[prop][paramName];

--- a/test/hellosign-sdk-test-server/lib/helpers.js
+++ b/test/hellosign-sdk-test-server/lib/helpers.js
@@ -90,7 +90,7 @@ var helpers = module.exports = {
 
         for(var prop in data){
             if (data.hasOwnProperty(prop)){
-                if (typeof data[prop] === "object" && prop != "files"){
+                if (typeof data[prop] === "object" && prop !== "files" && prop !== "filesData"){
                     for(var paramName in data[prop]){
                         if(data[prop].hasOwnProperty(paramName)){
                             data[prop + "[" + paramName + "]"] = data[prop][paramName];


### PR DESCRIPTION
This PR introduces the ability to directly upload a file in a signature request without first requiring that file to be somewhere on a filesystem. While a caller _may_ have a file to pass, it's also reasonable to assume that the caller may only have the file in-memory, perhaps from a previous operation (such downloading from a URL or generating from somewhere).

Fixes https://github.com/HelloFax/hellosign-nodejs-sdk/issues/97